### PR TITLE
(test) Upgrade doctrine/mongodb-odm & doctrine/mongodb-odm-bundle to their last major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,9 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/mongodb-odm": "^1.0",
-        "doctrine/mongodb-odm-bundle": "^3.0",
+        "alcaeus/mongo-php-adapter": "^1.1",
+        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/mongodb-odm-bundle": "^4.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.8",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
@@ -49,7 +50,10 @@
         "alcaeus/mongo-php-adapter": "Allows usage of PHP 7"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "ext-mongo": "1.6.16"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "sonata-project/admin-bundle": "^3.31",
@@ -50,10 +49,7 @@
         "alcaeus/mongo-php-adapter": "Allows usage of PHP 7"
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "ext-mongo": "1.6.16"
-        }
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Upgrade doctrine/mongodb-odm & doctrine/mongodb-odm-bundle to their last major version

Upgrade dependencies:
- `doctrine/mongodb-odm` from '^1.0.' to '^2.0' (BC: https://github.com/doctrine/mongodb-odm/pull/2069)
- `doctrine/mongodb-odm-bundle` from '3.0' to '4.0' (https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/UPGRADE-4.0.md)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.


